### PR TITLE
Add to send requests repeatedly to resolve html errors that a…

### DIFF
--- a/21.getcontent.sh
+++ b/21.getcontent.sh
@@ -33,6 +33,13 @@ do
 		PREFIX="[$PROCNUM] $PREFIX"
 	fi
 	curl_post 2>/dev/null
+	size=$(stat -c%s "$OUTFILE")
+	while [[ "$size" -lt 1000 ]]
+	do
+		rm "$OUTFILE"
+		curl_post 2>/dev/null
+		size=$(stat -c%s "$OUTFILE")
+	done
 	ATTIDX=$(grep attachIdx $OUTFILE | awk -F'"' '{print $8}')
 	FILESEQ="1"
 	if grep posFileSeq $OUTFILE | grep -q checkbox; then


### PR DESCRIPTION
url: https://ithub.korean.go.kr/user/total/database/electronicDicView.do에
요청을 보내 html/article-{index}.html 파일을 생성할 때
언어정보나눔터에서 알수없는 에러가 발생해 해당 페이지에 제대로 접근을 하지 못해 
article파일에 정확한 html이 아닌채로 생성되는 경우가 있습니다.
#2 해당 이슈도 비슷한 문제라고 생각됩니다.

해당 오류를 해결하기 위해서
제대로된 파일이 생성될때까지 같은 url로 반복적으로 요청을 보내는 로직을 추가하였습니다.

좋은 소스를 공개해주셔서 감사합니다